### PR TITLE
fix: 修复半年显示

### DIFF
--- a/src/utils/formatHelper.ts
+++ b/src/utils/formatHelper.ts
@@ -71,7 +71,7 @@ export const formatPrice = (
     cycleStr = "月";
   } else if (billingCycle >= 89 && billingCycle <= 92) {
     cycleStr = "季";
-  } else if (billingCycle >= 180 && billingCycle <= 183) {
+  } else if (billingCycle >= 180 && billingCycle <= 184) {
     cycleStr = "半年";
   } else if (billingCycle >= 364 && billingCycle <= 366) {
     cycleStr = "年";


### PR DESCRIPTION
上游默认半年为 184 天
https://github.com/komari-monitor/komari-web/blob/969cb54d6ac8f2525cd7c27309a2d5e48dd4170c/src/pages/admin/index.tsx#L1681-L1696

后台配置周期：
<img width="192" height="181" alt="image" src="https://github.com/user-attachments/assets/9ba6f227-4806-4dc8-bc33-ad774d838774" />

后台显示周期：
<img width="240" height="94" alt="image" src="https://github.com/user-attachments/assets/a34b89ca-c15f-48c5-9713-ce002a8bfcd0" />

PurCarte 显示周期为天：
<img width="338" height="125" alt="image" src="https://github.com/user-attachments/assets/4792ce1f-b0be-47c1-a158-110fe17617db" />
